### PR TITLE
Compatible gd plugin cinfig with php 7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN docker-php-ext-configure intl \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install pdo_pgsql \
     && docker-php-ext-install soap \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install opcache \
     && docker-php-ext-install mysqli \


### PR DESCRIPTION
A number of extensions have been migrated to exclusively use pkg-config for the
detection of library dependencies. Generally, this means that instead of using
--with-foo-dir=DIR or similar only --with-foo is used. Custom library paths can
be specified either by adding additional directories to PKG_CONFIG_PATH or by
explicitly specifying compilation options through FOO_CFLAGS and FOO_LIBS